### PR TITLE
fix get_price interface

### DIFF
--- a/src/interfaces/IConnectOracle.sol
+++ b/src/interfaces/IConnectOracle.sol
@@ -11,10 +11,7 @@ interface IConnectOracle {
     }
 
     function get_all_currency_pairs() external returns (string memory);
-    function get_price(
-        string memory base,
-        string memory quote
-    ) external returns (Price memory);
+    function get_price(string memory pair_id) external returns (Price memory);
     function get_prices(
         string[] memory pair_ids
     ) external returns (Price[] memory);

--- a/src/interfaces/IConnectOracle.sol
+++ b/src/interfaces/IConnectOracle.sol
@@ -12,7 +12,5 @@ interface IConnectOracle {
 
     function get_all_currency_pairs() external returns (string memory);
     function get_price(string memory pair_id) external returns (Price memory);
-    function get_prices(
-        string[] memory pair_ids
-    ) external returns (Price[] memory);
+    function get_prices(string[] memory pair_ids) external returns (Price[] memory);
 }


### PR DESCRIPTION
- match `get_price` interface between `IConnectOracle.sol` and `ConnectOracle.sol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified the `get_price` function to accept a single parameter for currency pairs.

- **Bug Fixes**
	- Improved input handling by reducing the number of parameters required for the `get_price` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->